### PR TITLE
Update jmeter url

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,5 +46,5 @@ variable "jmx_script_file" {
 
 variable "jmeter3_url" {
   description = "URL with jmeter archive"
-  default = "http://apache-mirror.rbc.ru/pub/apache/jmeter/binaries/apache-jmeter-3.0.tgz" 
+  default = "http://apache-mirror.rbc.ru/pub/apache/jmeter/binaries/apache-jmeter-3.3.tgz" 
 }


### PR DESCRIPTION
<img width="1126" alt="screen shot 2018-01-03 at 5 09 16 pm" src="https://user-images.githubusercontent.com/1470297/34512957-e9c86d80-f0a8-11e7-871d-08bed0a48c60.png">

urrent `jmeter3_url` resolves to 404.

Not sure if this is a sustainable fix, since it seems that apache takes down old binaries.